### PR TITLE
Update documentation to adhere to RFC

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Client example:
     import wspy
     sock = wspy.websocket(location='/my/path')
     sock.connect(('', 8000))
-    sock.send(wspy.Frame(wspy.OPCODE_TEXT, 'Hello, Server!'))
+    sock.send(wspy.Frame(wspy.OPCODE_TEXT, 'Hello, Server!', mask=True))
 
 
 Sending messages with a connection


### PR DESCRIPTION
RFC6455 reads:

> 5.1.  Overview
>
> In the WebSocket Protocol, data is transmitted using a sequence of
> frames.  To avoid confusing network intermediaries (such as
> intercepting proxies) and for security reasons that are further
> discussed in Section 10.3, a client MUST mask all frames that it sends
> to the server (see Section 5.3 for further details).  (Note that
> masking is done whether or not the WebSocket Protocol is running over
> TLS.)  The server MUST close the connection upon receiving a frame
> that is not masked.

https://tools.ietf.org/html/rfc6455#section-5.1

Update the usage example to adhere to this requirement.

---

[The Google Chrome browser exposes a WebSocket server for automation purposes](https://chromedevtools.github.io/devtools-protocol/), and it ignores client frames which aren't masked.